### PR TITLE
Fix low-contrast info box on door page

### DIFF
--- a/door/door.css
+++ b/door/door.css
@@ -27,7 +27,8 @@ header h1 {
 }
 
 #info div {
-    background-color: #eeeeee;
+    background-color: #d8d8d8;
+    border: 1px solid #b9b9b9;
     flex: 1;
 }
 


### PR DESCRIPTION
Darkens the info panel background and adds a subtle border in door/door.css so content remains visible through the door monitor/glass conditions.

Closes #57