### PR TITLE
fix: add missing fonts.css to dev team page

### DIFF
--- a/dev/devTeam.html
+++ b/dev/devTeam.html
@@ -3,6 +3,7 @@
     <head>
         <title>UWRF ACM Dev Team</title>
         <link rel="stylesheet" href="../style.css">
+        <link rel="stylesheet" href="../fonts.css">
         <meta charset="UTF-8">
         <meta name="description" content="Information about the Dev Team">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
saw the issue about missing fonts on the dev team page. checked the main index.html and it has fonts.css referenced but devTeam.html was missing it.

added the fonts.css link so now it should use the proper fonts instead of system defaults.

closes #64