### PR TITLE
Adds a loading indicator

### DIFF
--- a/dev/projects/petapolis.html
+++ b/dev/projects/petapolis.html
@@ -16,6 +16,8 @@
     <link rel="stylesheet" href="../../style.css">
     <link rel="stylesheet" href="../../fonts.css">
     <link rel="stylesheet" href="projects.css">
+    <script src="../../main.js"></script>
+    <script src="projects.js"></script>
 </head>
 <body>
 <main>

--- a/dev/projects/projects.js
+++ b/dev/projects/projects.js
@@ -1,3 +1,5 @@
+// TODO: Extra credit: There's a slight vertical shift this causes I can't figure out. Fix it!
+
 window.addEventListener("DOMContentLoaded", () => {
     loadOne(document.querySelector("#content iframe"));
 })

--- a/dev/projects/projects.js
+++ b/dev/projects/projects.js
@@ -1,0 +1,3 @@
+window.addEventListener("DOMContentLoaded", () => {
+    loadOne(document.querySelector("#content iframe"));
+})

--- a/main.js
+++ b/main.js
@@ -5,11 +5,23 @@ function loadingBars(startingPoint) {
             iframes[i].parentElement.querySelector(".loading").remove();
             iframes[i].classList.remove("hidden");
         });
-        const loadingDiv = document.createElement("div");
-        loadingDiv.classList.add("loading");
-        loadingDiv.style.width = iframes[i].offsetWidth + "px";
-        loadingDiv.style.height = iframes[i].offsetHeight + "px"
-        iframes[i].before(loadingDiv);
-        iframes[i].classList.add("hidden");
+        createLoadingDiv(iframes[i]);
     }
+}
+
+function loadOne(element) {
+    element.addEventListener("load", () => {
+        element.parentElement.querySelector(".loading").remove();
+        element.classList.remove("hidden");
+    });
+    createLoadingDiv(element);
+}
+
+function createLoadingDiv(element) {
+    const loadingDiv = document.createElement("div");
+    loadingDiv.classList.add("loading");
+    loadingDiv.style.width = element.offsetWidth + "px";
+    loadingDiv.style.height = element.offsetHeight + "px"
+    element.before(loadingDiv);
+    element.classList.add("hidden");
 }

--- a/main.js
+++ b/main.js
@@ -1,0 +1,15 @@
+function loadingBars(startingPoint) {
+    const iframes = startingPoint.querySelectorAll("iframe");
+    for (let i = 0; i < iframes.length; i++) {
+        iframes[i].addEventListener("load", () => {
+            iframes[i].parentElement.querySelector(".loading").remove();
+            iframes[i].classList.remove("hidden");
+        });
+        const loadingDiv = document.createElement("div");
+        loadingDiv.classList.add("loading");
+        loadingDiv.style.width = iframes[i].offsetWidth + "px";
+        loadingDiv.style.height = iframes[i].offsetHeight + "px"
+        iframes[i].before(loadingDiv);
+        iframes[i].classList.add("hidden");
+    }
+}

--- a/style.css
+++ b/style.css
@@ -65,5 +65,28 @@ div#content {
 }
 
 .loading {
-    background-color: gray;
+    background-image: linear-gradient(to bottom right, lightgray, darkgray, lightgray);
+    background-size: 200% 200%;
+    animation-name: loading;
+    animation-duration: 2s;
+    animation-iteration-count: infinite;
+    animation-timing-function: linear;
+}
+
+@keyframes loading {
+    0% {
+        background-position: 0 0;
+    }
+    25% {
+        background-position: 25% 25%;
+    }
+    50% {
+        background-position: 50% 50%;
+    }
+    75% {
+        background-position: 75% 75%;
+    }
+    100% {
+        background-position: 100% 100%;
+    }
 }

--- a/style.css
+++ b/style.css
@@ -59,3 +59,11 @@ div#content {
     overflow: auto;
     margin: 0 1.5rem;
 }
+
+.hidden {
+    display: none;
+}
+
+.loading {
+    background-color: gray;
+}


### PR DESCRIPTION
Applies it to the petapolis iframe
Resolves #83

Notes: The loading indicator is slightly smaller vertically than the iframe for some reason, which makes the content jump a little.
Also, the animation doesn't loop seamlessly.