### PR TITLE
fixes mobile support for screens down to 400px wide

### DIFF
--- a/header/topBar.css
+++ b/header/topBar.css
@@ -21,6 +21,26 @@
     color: var(--subaccent-color);
 }
 
+@media screen and (max-width: 69rem) {
+    header {
+        max-width: 100% !important;
+        min-width: 100% !important;
+        /* justify-content: center !important; */
+    }
+    #headersHeader h2 {
+        font-size: large !important;
+        top: 0.75rem !important;
+    }
+    a {
+        margin-left: 1rem !important; 
+        min-width: 4rem !important;
+        padding: 0.5rem !important;
+    }
+    a:hover {
+        animation: none;
+    }
+}
+
 header {
     display: flex;
     flex-direction: row;

--- a/header/topBar.css
+++ b/header/topBar.css
@@ -25,7 +25,6 @@
     header {
         max-width: 100% !important;
         min-width: 100% !important;
-        /* justify-content: center !important; */
     }
     #headersHeader h2 {
         font-size: large !important;
@@ -37,7 +36,7 @@
         padding: 0.5rem !important;
     }
     a:hover {
-        animation: none;
+        animation: none !important;
     }
 }
 

--- a/style.css
+++ b/style.css
@@ -30,10 +30,10 @@ main {
     background-color: var(--body-color);
 }
 
-@media screen and (max-width: 70rem) {
+@media screen and (max-width: 69rem) {
     main {
-        max-width: 100%;
-        min-width: 100%;
+        max-width: 100% !important;
+        min-width: 100% !important;
     }
 }
 


### PR DESCRIPTION
also marks all media query styles as !important
also changes threshhold for mobile screen to a width of 69rem since 70rem meant that 1280p screens were counted as mobile (consider using aspect ratio as a threshold for mobile in the media query also?)
resolves #91 